### PR TITLE
Allowed the web container to be scalable.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,6 @@ services:
     volumes:
       - ./web:/code
     ports:
-      - "8000:8000"
+      - "8000"
     depends_on:
       - db


### PR DESCRIPTION
Removed the hard-coded host port for the web container so that Docker can assign this.
